### PR TITLE
Accessible Colour Palettes 

### DIFF
--- a/src/Pages/Quarto.elm
+++ b/src/Pages/Quarto.elm
@@ -1,6 +1,6 @@
 module Pages.Quarto exposing (Model, Msg, Params, page)
 
-import Element exposing (Element, rgb255)
+import Element exposing (Element)
 import Element.Border as Border
 import Element.Font as Font
 import Element.Input as Input
@@ -8,6 +8,7 @@ import List.Extra as Liste
 import Spa.Document exposing (Document)
 import Spa.Page as Page exposing (Page)
 import Spa.Url as Url exposing (Url)
+import Styles
 import Svg exposing (Svg, svg)
 import Svg.Attributes as Attr
 
@@ -372,7 +373,7 @@ viewCell ( name, status ) =
 
 viewCellButton : Cell -> Element Msg
 viewCellButton cell =
-    Input.button [ Border.color (rgb255 52 42 31), Border.width 5 ] { onPress = Just (PlaceAttempt cell), label = viewCell cell }
+    Input.button [ Border.color Styles.black, Border.width 5 ] { onPress = Just (PlaceAttempt cell), label = viewCell cell }
 
 
 viewBoard : CellBoard -> Element Msg
@@ -430,10 +431,14 @@ colourfunc : Colour -> List (Svg.Attribute msg)
 colourfunc colour =
     case colour of
         Black ->
-            [ Attr.color "#CAB8CB" ]
+            [ Styles.colortoCssRGBString Styles.red
+                |> Attr.color
+            ]
 
         White ->
-            [ Attr.color "#DCB69F" ]
+            [ Styles.colortoCssRGBString Styles.yellow
+                |> Attr.color
+            ]
 
 
 patternfunc : Pattern -> List (Svg.Attribute msg)

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -14,6 +14,7 @@ import Element.Background as Background
 import Element.Font as Font
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
+import Styles
 import Url exposing (Url)
 
 
@@ -70,9 +71,9 @@ view { page, toMsg } model =
     { title = page.title
     , body =
         [ column [ spacing 20, height fill, width fill ]
-            [ row [ width fill, spacing 20, padding 20, Background.color (rgb255 52 42 31) ]
-                [ link [ Font.color (rgb255 255 255 255) ] { url = Route.toString Route.Top, label = text "Homepage" }
-                , link [ Font.color (rgb255 255 255 255) ] { url = Route.toString Route.Quarto, label = text "Game" }
+            [ row [ width fill, spacing 20, padding 20, Background.color Styles.blue ]
+                [ link [ Font.color Styles.white ] { url = Route.toString Route.Top, label = text "Homepage" }
+                , link [ Font.color Styles.white ] { url = Route.toString Route.Quarto, label = text "Game" }
                 ]
             , column [ height fill, centerX ] page.body
             ]

--- a/src/Styles.elm
+++ b/src/Styles.elm
@@ -1,0 +1,50 @@
+module Styles exposing (black, blue, colortoCssRGBString, red, white, yellow)
+
+import Element exposing (Color, rgb255)
+
+
+
+-- Accessible color pallette for use throughout application:
+--    all text should be either black or white
+--    black text should be used with red and yellow backgrounds
+--    white text should be used with blue backgrounds
+
+
+black : Color
+black =
+    rgb255 0 0 0
+
+
+white : Color
+white =
+    rgb255 255 255 255
+
+
+blue : Color
+blue =
+    rgb255 0 68 136
+
+
+red : Color
+red =
+    rgb255 187 85 102
+
+
+yellow : Color
+yellow =
+    rgb255 221 170 51
+
+
+colortoCssRGBString : Color -> String
+colortoCssRGBString color =
+    let
+        rgb =
+            Element.toRgb color
+    in
+    "rgb("
+        ++ String.fromFloat (rgb.red * 255)
+        ++ ","
+        ++ String.fromFloat (rgb.green * 255)
+        ++ ","
+        ++ String.fromFloat (rgb.blue * 255)
+        ++ ")"


### PR DESCRIPTION
Issue ref: #8  

- Added a styles.elm file containing the Styles module.
- Added color variables for a simple color palette based on the work of Paul Tol ` https://personal.sron.nl/~pault/`
- Changed any direct calls to Element.RGB255 to reference the new Styles color variables

Color can now be managed globally in Styles.elm

In addition to the original issue I have also replaced the color references in Quarto.elm as these were hard-coded hex colors. 
To do this I created a method in Styles.elm that can turn an Element.Color into a CSS style RGB string.  Now the color of the game pieces can use the global palette.

Hope it's okay. Happy to make changes if needed.

Thanks

Adam
