### PR TITLE
Check for NoPieceSelected

### DIFF
--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -444,7 +444,7 @@ updateGamepiecePlaced { cellname, cellstate } model =
 updateSelectingGamepiece : Gamepiece -> Model -> Model
 updateSelectingGamepiece gamepiece model =
     case model.gamestatus of
-        GameInProgress player _ ->
+        GameInProgress player NoPieceSelected ->
             let
                 newActiveplayer =
                     updateActiveplayer player


### PR DESCRIPTION
**DESCRIPTION**

Fixes a bug where the `updateSelectedGamepiece` function was firing when there was already a game piece selected.
