### PR TITLE
Update webmanifest and tags

### DIFF
--- a/public/favicon_package_v0/site.webmanifest
+++ b/public/favicon_package_v0/site.webmanifest
@@ -1,6 +1,7 @@
 {
-    "name": "",
-    "short_name": "",
+    "name": "Elm Quarto",
+    "short_name": "Elm Quarto",
+    "description": "Functional and accessible web app based on the popular (and highly entertaining) board game Quarto.",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",
@@ -13,7 +14,7 @@
             "type": "image/png"
         }
     ],
-    "theme_color": "#ffffff",
+    "theme_color": "#000000",
     "background_color": "#ffffff",
     "display": "standalone"
 }

--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
   <link rel="apple-touch-icon" sizes="180x180" href="/favicon_package_v0/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon_package_v0/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon_package_v0/favicon-16x16.png">
+  <link rel="shortcut icon" href="/favicon_package_v0/favicon.ico">
   <link rel="manifest" href="/favicon_package_v0/site.webmanifest">
   <link rel="mask-icon" href="/favicon_package_v0/safari-pinned-tab.svg" color="#60b5cc">
   <meta name="msapplication-TileColor" content="#da532c">


### PR DESCRIPTION
**LINKED ISSUE**
It should solve #4 

**DESCRIPTION**
I'm including the properties requested in #4 for the existing `manifest.webmanifest` and a link to the favicon.

**METHODOLOGY**
The Mozilla [documentation](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps) about PWA says that technically a PWA needs a Maniflest file. There are many properties for a [manifest](https://developer.mozilla.org/en-US/docs/Web/Manifest#Creating_a_valid_manifest) and the ones described in the issue are a good start.
