### PR TITLE
Update GH link to match site tone

### DIFF
--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -100,4 +100,4 @@ body listy =
 footer : Element msg
 footer =
     row [ width fill, spacing 20, padding 20, Background.color Styles.black ]
-        [ newTabLink [ Font.color Styles.white, centerX ] { url = "https://github.com/tkshill/Quarto", label = text "GitHub Repository" } ]
+        [ newTabLink [ Font.color Styles.white, centerX ] { url = "https://github.com/tkshill/Quarto", label = text "Checkout the GitHub Repository!" } ]


### PR DESCRIPTION
### DESCRIPTION

Proposed update to make the GH link more inviting. 

<img width="314" alt="Screen Shot 2020-10-27 at 8 41 27 PM" src="https://user-images.githubusercontent.com/19792273/97390599-7c0a1d80-189a-11eb-9f42-5a440ced44ee.png">
