### PR TITLE
Add aria attributes

### DIFF
--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -629,7 +629,7 @@ view : Model -> Document Msg
 view model =
     { title = "Quarto - Play"
     , body =
-        [ column [ spacing 10, centerX ]
+        [ column [ spacing 10, centerX, Region.mainContent ]
             [
               viewRemainingPieces model.remainingPieces
             , viewGamestatus model.gamestatus

--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -718,7 +718,7 @@ viewRestartButton =
 
 viewBoard : CellBoard -> Element Msg
 viewBoard cellboard =
-    column [ centerX ]
+    column [ centerX, Region.announce ]
         [  el [ Font.center, width fill ] (text "GameBoard")
         , row [] <| List.map viewCellButton [ cellboard.a1, cellboard.b1, cellboard.c1, cellboard.d1 ]
         , row [] <| List.map viewCellButton [ cellboard.a2, cellboard.b2, cellboard.c2, cellboard.d2 ]

--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -703,7 +703,7 @@ viewRestartButton =
 
 viewBoard : CellBoard -> Element Msg
 viewBoard cellboard =
-    column [ centerX ]
+    column [ centerX, Region.announce ]
         [ row [] <| List.map viewCellButton [ cellboard.a1, cellboard.b1, cellboard.c1, cellboard.d1 ]
         , row [] <| List.map viewCellButton [ cellboard.a2, cellboard.b2, cellboard.c2, cellboard.d2 ]
         , row [] <| List.map viewCellButton [ cellboard.a3, cellboard.b3, cellboard.c3, cellboard.d3 ]

--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -718,14 +718,9 @@ viewRestartButton =
 
 viewBoard : CellBoard -> Element Msg
 viewBoard cellboard =
-<<<<<<< HEAD
-    column [ centerX, Region.announce ]
-        [ row [] <| List.map viewCellButton [ cellboard.a1, cellboard.b1, cellboard.c1, cellboard.d1 ]
-=======
     column [ centerX ]
         [  el [ Font.center, width fill ] (text "GameBoard")
         , row [] <| List.map viewCellButton [ cellboard.a1, cellboard.b1, cellboard.c1, cellboard.d1 ]
->>>>>>> main
         , row [] <| List.map viewCellButton [ cellboard.a2, cellboard.b2, cellboard.c2, cellboard.d2 ]
         , row [] <| List.map viewCellButton [ cellboard.a3, cellboard.b3, cellboard.c3, cellboard.d3 ]
         , row [] <| List.map viewCellButton [ cellboard.a4, cellboard.b4, cellboard.c4, cellboard.d4 ]

--- a/src/Pages/GamePage.elm
+++ b/src/Pages/GamePage.elm
@@ -629,7 +629,7 @@ view : Model -> Document Msg
 view model =
     { title = "Quarto - Play"
     , body =
-        [ column [ spacing 10, centerX, Region.mainContent ]
+        [ column [ spacing 10, centerX ]
             [
               viewRemainingPieces model.remainingPieces
             , viewGamestatus model.gamestatus

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -72,16 +72,8 @@ view { page } _ =
     { title = page.title
     , body =
         [ column [ spacing 20, height fill, width fill ]
-<<<<<<< HEAD
-            [ row [ width fill, spacing 20, padding 20, Background.color Styles.blue, Region.navigation ]
-                [ link [ Font.color Styles.white ] { url = Route.toString Route.Top, label = text "Home" }
-                , link [ Font.color Styles.white ] { url = Route.toString Route.GamePage, label = text "Play!" }
-                ]
-            , column [ height fill, centerX, Region.mainContent ] page.body
-=======
             [ header
             , viewBody page.body
->>>>>>> main
             ]
         ]
     }

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -76,7 +76,7 @@ view { page } _ =
                 [ link [ Font.color Styles.white ] { url = Route.toString Route.Top, label = text "Home" }
                 , link [ Font.color Styles.white ] { url = Route.toString Route.GamePage, label = text "Play!" }
                 ]
-            , column [ height fill, centerX ] page.body
+            , column [ height fill, centerX, Region.mainContent ] page.body
             ]
         ]
     }

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -12,6 +12,7 @@ import Browser.Navigation exposing (Key)
 import Element exposing (centerX, column, fill, height, link, padding, row, spacing, text, width)
 import Element.Background as Background
 import Element.Font as Font
+import Element.Region as Region
 import Spa.Document exposing (Document)
 import Spa.Generated.Route as Route
 import Styles
@@ -71,7 +72,7 @@ view { page } _ =
     { title = page.title
     , body =
         [ column [ spacing 20, height fill, width fill ]
-            [ row [ width fill, spacing 20, padding 20, Background.color Styles.blue ]
+            [ row [ width fill, spacing 20, padding 20, Background.color Styles.blue, Region.navigation ]
                 [ link [ Font.color Styles.white ] { url = Route.toString Route.Top, label = text "Home" }
                 , link [ Font.color Styles.white ] { url = Route.toString Route.GamePage, label = text "Play!" }
                 ]

--- a/src/Shared.elm
+++ b/src/Shared.elm
@@ -71,7 +71,7 @@ view :
 view { page } _ =
     { title = page.title
     , body =
-        [ column [ spacing 20, height fill, width fill ]
+        [ column [ spacing 20, height fill, width fill, Region.mainContent ]
             [ header
             , viewBody page.body
             ]
@@ -79,7 +79,7 @@ view { page } _ =
     }
 
 header: Element.Element msg
-header = row [ width fill, spacing 20, padding 20, Background.color Styles.blue ]
+header = row [ width fill, spacing 20, padding 20, Background.color Styles.blue, Region.navigation ]
                 [ link [ Font.color Styles.white ] { url = Route.toString Route.Top, label = text "Home" }
                 , link [ Font.color Styles.white ] { url = Route.toString Route.GamePage, label = text "Play!" }
                 ]


### PR DESCRIPTION
## Add LINKED ISSUE (if relevant) here

#22 

---

## Add DESCRIPTION of solution describing what changes you've made below.

Add `Region.announce` to `viewBoard` column in `GamePage.elm`

Add `Region.mainContent` to `view` in `Shared.elm`

Add `Region.navigation` to header row in `Shared.elm`



---

## Use this section for METHODOLOGY and any supporting docs/ links/ articles**

Although I've added the three attributes from the Elm Region library, the only aria-label visible in the output HTML is an `aria-live=polite` on the game board. As discussed, I'm submitting this PR anyway with that as a known issue.