### PR TITLE
feat(UI): Make the Restart button look nicer

### DIFF
--- a/src/Pages/Top.elm
+++ b/src/Pages/Top.elm
@@ -184,7 +184,7 @@ viewGamestatus gamestatus dimensions =
     let
         containerize : List (Element Msg) -> Element Msg
         containerize elements =
-            el [ Font.center, centerX ] (column [ width fill, Font.center, centerX ] elements)
+            el [ Font.center, centerX ] (column [ width fill, spacing 5, Font.center, centerX ] elements)
     in
     case gamestatus of
         Won winner ->
@@ -243,7 +243,7 @@ viewCellButton cell =
 
 viewRestartButton : Element Msg
 viewRestartButton =
-    Input.button [ Background.color Styles.blue, Border.width 5, Font.color Styles.white ]
+    Input.button [ Background.color Styles.white, Border.width 5, Border.color Styles.blue, padding 5, centerX, Font.color Styles.blue ]
         { onPress = Just (GameMessage RestartWanted), label = text "Restart" }
 
 


### PR DESCRIPTION
## Add LINKED ISSUE (if relevant) here

#49 

---

## Add DESCRIPTION of solution describing what changes you've made below.

Added padding around text
Added spacing between other text and button
Centered button
Restyled button to have blue border, black text and white background

---

## Use this section for METHODOLOGY and any supporting docs/ links/ articles**

I think it looks nicer with the revised colour combination, but feel free to reject this bit if you don't like it. Screenshot attached.
![2020-11-19 19 46 26 localhost 22b356850c50](https://user-images.githubusercontent.com/26224873/99719051-b898f580-2aa3-11eb-9600-4069c30304f8.png)


