### PR TITLE
Add message when player clicks buttons out of turn.

### DIFF
--- a/src/Game.elm
+++ b/src/Game.elm
@@ -141,7 +141,7 @@ update msg (Model model) =
                    )
 
         ( ComputerSelectedPiece piece, InPlay Computer ChoosingPiece ) ->
-            Model model
+            Model { model | statusMessage = NoMessage }
                 |> noCmds
                 |> map (nextPlayerStartsPlaying Computer piece)
 

--- a/src/Game.elm
+++ b/src/Game.elm
@@ -5,6 +5,7 @@ module Game exposing
     , Msg(..)
     , Player(..)
     , Turn(..)
+    , StatusMessage(..)
     , currentStatus
     , gameboard
     , init
@@ -12,6 +13,7 @@ module Game exposing
     , pieceToString
     , playerToString
     , remainingPieces
+    , currentStatusMessage
     , update
     )
 
@@ -68,9 +70,13 @@ type GameStatus
     | Won Winner
     | Draw
 
+type StatusMessage
+    = NoMessage
+    | SomePiecePlayedWhenNotPlayersTurn
+
 
 type Model
-    = Model { board : Board, status : GameStatus }
+    = Model { board : Board, status : GameStatus, statusMessage : StatusMessage }
 
 
 
@@ -82,9 +88,13 @@ initStatus =
     InPlay Human ChoosingPiece
 
 
+initStatusMessage : StatusMessage
+initStatusMessage = NoMessage
+
+
 init : Model
 init =
-    Model { board = Board.init, status = initStatus }
+    Model { board = Board.init, status = initStatus, statusMessage = initStatusMessage }
 
 
 
@@ -113,6 +123,10 @@ update msg (Model model) =
                 |> map (nextPlayerStartsPlaying Human piece)
                 |> andThen (computerChooses ComputerSelectedCell Board.openCells)
 
+        ( HumanSelectedPiece piece, _ ) ->
+            Model { model | statusMessage = SomePiecePlayedWhenNotPlayersTurn }
+                |> noCmds
+
         ( ComputerSelectedCell name, InPlay Computer (ChoosingCellToPlay piece) ) ->
             Model model
                 |> noCmds
@@ -132,7 +146,7 @@ update msg (Model model) =
                 |> map (nextPlayerStartsPlaying Computer piece)
 
         ( HumanSelectedCell name, InPlay Human (ChoosingCellToPlay piece) ) ->
-            Model model
+            Model { model | statusMessage = NoMessage }
                 |> noCmds
                 |> map (playerTryPlay name piece)
                 |> (\( maybeModel, c ) ->
@@ -268,6 +282,11 @@ remainingPieces (Model model) =
 currentStatus : Model -> GameStatus
 currentStatus (Model model) =
     model.status
+
+
+currentStatusMessage : Model -> StatusMessage
+currentStatusMessage (Model model) =
+    model.statusMessage
 
 
 playerToString : Player -> String

--- a/src/Pages/Top.elm
+++ b/src/Pages/Top.elm
@@ -38,6 +38,7 @@ import Game
         , Msg(..)
         , Player(..)
         , Turn(..)
+        , StatusMessage(..)
         )
 import Game.Core
     exposing
@@ -154,6 +155,7 @@ view model =
                 , viewRemainingPieces (Game.remainingPieces model.game)
                 ]
             , viewGamestatus (Game.currentStatus model.game) model.dimensions
+            , viewStatusMessage (Game.currentStatusMessage model.game)
             ]
         ]
     }
@@ -221,6 +223,14 @@ viewGamestatus gamestatus dimensions =
             containerize
                 [ script ]
 
+
+viewStatusMessage : StatusMessage -> Element Msg
+viewStatusMessage statusMessage =
+    case statusMessage of
+        NoMessage ->
+            Element.el [] (Element.text "")
+        SomePiecePlayedWhenNotPlayersTurn ->
+            Element.el [ centerX, Font.center, Region.announce ] (Element.text "It's not your turn to choose a piece!")
 
 viewCell : Cell -> Element Msg
 viewCell { name, status } =


### PR DESCRIPTION
## Add LINKED ISSUE (if relevant) here

#48 

---

## Add DESCRIPTION of solution describing what changes you've made below.

Added message that appears when player clicks on a piece out of their turn to select a piece, and relevant underlying game logic.

---

## Use this section for METHODOLOGY and any supporting docs/ links/ articles**

The type `StatusMessage` and function `currentStatusMessage` have been added to the Game API to facilitate exchange of information between `Top.elm` & `Game.elm`.

The `StatusMessage` type has two variants, `NoMessage` and `SomePiecePlayedWhenNotPlayersTurn`. This would be easily expandable if further messages were desired to be represented using a variant for each message that the game might display.

`statusMessage` is part of the `Game.elm` `model` and initialised to `NoMessage` since the player should not see a message unless an event occurs requiring one to be displayed.

`update` in `Game.elm` has a new case for the message `HumanSelectedPiece piece` where `model.status` is not `InPlay Human ChoosingPiece`. This case causes `model.statusMessage` to be updated to `SomePiecePlayedWhenNotPlayersTurn`. This covers all circumstances of a piece being selected by the player out of turn. This solution negates the need to alter `ViewRemainingPiecesButton` in `Top.elm`. The case `HumanSelectedCell name, InPlay Human (ChoosingCellToPlay piece)` reverts `model.statusMessage` to `NoMessage` in order to remove the message just before the player's next turn to select a piece. (There may be alternative functionality solutions that would improve on this).


